### PR TITLE
add missing --dev install required for tests

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -7,6 +7,7 @@ Use `pipenv` (which you can install with `pip`).
 
 Run tests:
 
+    pipenv install --dev
     pipenv run pytest
 
     # for coverage:


### PR DESCRIPTION
Without this, pipenv will fail to find pytest or worse, will pick up
the default one from the system, which might be 2.7 or some other
version of pytest we don't want (*and* that won't pick up on the
virtualenv either).