### PR TITLE
WIP: switch from pykafka to confluent-kafka

### DIFF
--- a/extra/docker/docker-compose.yml
+++ b/extra/docker/docker-compose.yml
@@ -5,8 +5,7 @@ services:
     ports:
       - "2181:2181"
   kafka:
-    #image: wurstmeister/kafka:2.11-2.0.0
-    image: wurstmeister/kafka:2.11-1.1.1
+    image: wurstmeister/kafka:2.11-2.0.0
     ports:
       - "9092:9092"
     environment:
@@ -14,7 +13,7 @@ services:
       KAFKA_BROKER_ID: 1
       KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "fatcat-qa.changelog:1:1,fatcat-qa.release-updates:3:1:compact"
+      KAFKA_CREATE_TOPICS: "fatcat-dev.changelog:1:1,fatcat-dev.release-updates:3:1:compact"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   elasticsearch:

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -32,6 +32,7 @@ loginpass = "*"
 requests = ">=2"
 raven = { extras = ['flask'], version = "*" }
 pykafka = ">=2"
+confluent-kafka = "*"
 python-dateutil = "*"
 sickle = "*"
 python-snappy = "*"

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e071955278eb60cf551da9368dbb8878ce90a4d4ece74f5fba9513793412f802"
+            "sha256": "efc146663d0c828753796be47ed8b5412ad341276f468bb45645455fa166c4ab"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,10 @@
         },
         "authlib": {
             "hashes": [
-                "sha256:b61c6c6fd230c4ba8602fd85ee9a40e6dc859387699a1cd1f7247c4b109dcc17",
-                "sha256:eda3e5af921a368091fef721d6d169bcff2aa0003d05113bc26e127f58c9a5e8"
+                "sha256:3a226f231e962a16dd5f6fcf0c113235805ba206e294717a64fa8e04ae3ad9c4",
+                "sha256:9741db6de2950a0a5cefbdb72ec7ab12f7e9fd530ff47219f1530e79183cbaaf"
             ],
-            "version": "==0.10"
+            "version": "==0.11"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -120,6 +120,38 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "confluent-kafka": {
+            "hashes": [
+                "sha256:0043e55c7763f8c9658e46545a21a01dc42208f4d0c6b1c293a21c3ed564c9f6",
+                "sha256:0960a6281f127913b5f204442467a16974037f8447b42f1345f0c50305be48d3",
+                "sha256:2fb24f7ec787b4d352a66c9298df3374f0f240d54ddafeb6714ee439c2c18ab8",
+                "sha256:366dcda5f5e895351572c4a6db5bb072ea0868e08180f22ae1fd0da9b05bdcf0",
+                "sha256:37c33b0ded017a1959a90ec4fb13f4236876a5e6e7b6ec898a1d880f2b095d8d",
+                "sha256:3c53df7cd25855c46bc3c88e1331e5efc1910f452ed4a5c400a9579acac9057a",
+                "sha256:3c78b23239a041dfc0cbdb0a12ce9734696291f7358afcc0b721809ca2bb3301",
+                "sha256:4a7d41c896a2230f9d3682bc860c9296d62bcafbd82d65643873822bc5ca977b",
+                "sha256:57b0bf04c9fdc1c49d9c2673c57a8ecfc08476b250601787fd7d175a5c444afd",
+                "sha256:5d35b0160b54a52598f4f8fbb4a790f00d190a925034d6c97755c5be3ebb26a1",
+                "sha256:6a8eb66ca218ebf6852296830218e3bc9df982acef21a57c4bf468f6f8481d9c",
+                "sha256:6e7f683afc32cdc8db927df1e54a767e08a7c3cb35246f9b77c64a2ee48afacf",
+                "sha256:709f0a51cccb2b30c9046ade8099404c1f8f6ae0cf8c9b03bbd6e8957bf89439",
+                "sha256:70f9cffca40cfacdf9cbc5f0bbfb5bf484d993f1c75dd76b554635daac97de63",
+                "sha256:75a1c1ffd0b777714d3b2fe97874d7b21b1a17a6f726e711a1bc1446d8f9fda6",
+                "sha256:7745bcfabcc00f2c6d3391c6dda6e86d9386265fb183c75936a7a9571b1f470f",
+                "sha256:7912b1b8cf84af8d0e530d746356752e1ca6f8b08c59d64f4fa7457fbd7f556f",
+                "sha256:7d49bd472e3776706dc1ed60139fcc84a2f39097f0c6d9ae3f8a56e524a0ed6b",
+                "sha256:8282a33beba177f4026158848d2ae633132e88214a406d6c6b4ceeffe752f878",
+                "sha256:96348187a407603fdc43a6bb93c67962b0f098813ae6ee14e79a63937a3b0c11",
+                "sha256:a7427944af963410479c2aaae27cc9d28db39c9a93299f14dcf16df80092c63a",
+                "sha256:bf3efdb3418eb98a3eb6f32b20e3455c180d2208f5a8ef82c1021c1c2aeb54ed",
+                "sha256:c1fa55b97a56298a29e794c84681258d9e4a703b2c2d0411cae7e5016fb7adfd",
+                "sha256:cd13400d07d7f51c2f7b6d5b97986bf15ab3de6fdbac815acfac6ad70d54161f",
+                "sha256:d23e0fe4c60f45dc84af849c2d832658e11fb0383f3e005d4ebaa7938813a232",
+                "sha256:dbd110669d524835a728ba2df7cda048e21c65be34860fff7933509119c95ef8"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
         },
         "cryptography": {
             "hashes": [
@@ -220,10 +252,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "kazoo": {
             "hashes": [
@@ -645,10 +677,10 @@
         },
         "parso": {
             "hashes": [
-                "sha256:4580328ae3f548b358f4901e38c0578229186835f0fa0846e47369796dd5bcc9",
-                "sha256:68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db"
+                "sha256:17cc2d7a945eb42c3569d4564cdf49bde221bc2b552af3eca9c1aad517dcdd33",
+                "sha256:2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376"
             ],
-            "version": "==0.3.4"
+            "version": "==0.4.0"
         },
         "pathlib2": {
             "hashes": [
@@ -660,11 +692,11 @@
         },
         "pexpect": {
             "hashes": [
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==4.6.0"
+            "version": "==4.7.0"
         },
         "pg-view": {
             "hashes": [
@@ -697,19 +729,19 @@
         },
         "psycopg2": {
             "hashes": [
-                "sha256:2433931723bf6be4bd342e003ffa9a1cef2cb4de7735d5b063fd554fd64a744c",
-                "sha256:2a0497c8ade1a5a0dc3d62b7f1a4fbcbccfa15d9ef69cce064119cd723566392",
-                "sha256:3ad3cf4732ff7d87dc12031836e5097fc42be767193771da90b8b5038cdca412",
-                "sha256:453c5bc0563c9b9601ef9243c095da9e327f24da6917b7c3ede8e0cd9dd9477d",
-                "sha256:49c5838d90e83217909db3789d30a105385b5e696ec5168cda645546c542f35a",
-                "sha256:6d849117337afd1aa0a74ab9a6c9d2160228d25d5babfa4d9a98bf4a4dad8062",
-                "sha256:8980dbabfb2ed0866b6bd5687d1407c3bccaac1f2f496f1206472108be69b92d",
-                "sha256:a286480430af972be9c30333c48883890dc8d87eab0d591e24975dcf99abff6c",
-                "sha256:bc7ec9ab1f33edd5db40edfb407aabdc92e573c4fcacd9093a9a6f3dd93c7af2",
-                "sha256:d303d9f88ec839a51b430bbec0f4a8314d0d2a53f760e67e95e25e39f6d6fb5f",
-                "sha256:e9836455931ac3d91b71312fa3bb2b9db8c42720a53b7de7db082406e4828585"
+                "sha256:3648afc2b4828a6e00d516d2d09a260edd2c1e3de1e0d41d99c5ab004a73d180",
+                "sha256:5329b4530e31f58e0eafc55e26bbef684509bcc3be41604e45c0b98c297dc722",
+                "sha256:7c1ae1669d11105a002f804bebd7432f8dc7473459aa405164c6b44a922decd5",
+                "sha256:8af13498e32a00d0a66e43b7491c15231b27ab964ee4d2277a4a2dbadfb2c482",
+                "sha256:9d5489867bd5f6d6c6191a4debd8de9a5c03a9608cce3f4d7133e29e6bd4ec27",
+                "sha256:a17bfc9faffcca0ad9360c1ad97ab61ede583aa954715e8e436ffd80046661ff",
+                "sha256:b4a475ce87eabc0607e068a3c704d0aa0820237ed78d493b8e2d880eb73cd7fe",
+                "sha256:c49d66e97affdc80d084b3b363f09f17db621418f0b8e0524b06c54959e2094d",
+                "sha256:d13fbc3d533656cfdf094e13c1b0f40917b72813755ba780971ba0ce04280ac4",
+                "sha256:e1e4fe6e8ab9f9c7d28514d007f623999d2dd6b5b81069dd4f9d30dbdd6f7069",
+                "sha256:e67d60cb1a32f5fd8fcea935cf9efb1d1c26f96203b0ca2ae98c4c40ef8d8eac"
             ],
-            "version": "==2.8"
+            "version": "==2.8.1"
         },
         "ptyprocess": {
             "hashes": [

--- a/python/fatcat_harvest.py
+++ b/python/fatcat_harvest.py
@@ -81,8 +81,8 @@ def main():
         default="localhost:9092",
         help="list of Kafka brokers (host/port) to use")
     parser.add_argument('--env',
-        default="qa",
-        help="Kafka topic namespace to use (eg, prod, qa)")
+        default="dev",
+        help="Kafka topic namespace to use (eg, prod, qa, dev)")
     parser.add_argument('--start-date',
         default=None, type=mkdate,
         help="begining of harvest period")

--- a/python/fatcat_import.py
+++ b/python/fatcat_import.py
@@ -12,7 +12,8 @@ def run_crossref(args):
         edit_batch_size=args.batch_size,
         bezerk_mode=args.bezerk_mode)
     if args.kafka_mode:
-        KafkaJsonPusher(fci, args.kafka_hosts, args.kafka_env, "api-crossref", "fatcat-import").run()
+        KafkaJsonPusher(fci, args.kafka_hosts, args.kafka_env, "api-crossref",
+            "fatcat-import", edit_batch_size=args.batch_size).run()
     else:
         JsonLinePusher(fci, args.json_file).run()
 
@@ -93,7 +94,7 @@ def main():
         default="localhost:9092",
         help="list of Kafka brokers (host/port) to use")
     parser.add_argument('--kafka-env',
-        default="qa",
+        default="dev",
         help="Kafka topic namespace to use (eg, prod, qa)")
     parser.add_argument('--batch-size',
         help="size of batch to send",

--- a/python/fatcat_tools/harvest/doi_registrars.py
+++ b/python/fatcat_tools/harvest/doi_registrars.py
@@ -57,6 +57,7 @@ class HarvestCrossrefWorker:
         self.kafka_config = {
             'bootstrap.servers': kafka_hosts,
             'delivery.report.only.error': True,
+            'message.max.bytes': 20000000, # ~20 MBytes; broker is ~50 MBytes
             'default.topic.config': {
                 'request.required.acks': 'all',
             },

--- a/python/fatcat_tools/harvest/doi_registrars.py
+++ b/python/fatcat_tools/harvest/doi_registrars.py
@@ -113,6 +113,8 @@ class HarvestCrossrefWorker:
                 # crude backoff; now redundant with session exponential
                 # backoff, but allows for longer backoff/downtime on remote end
                 print("got HTTP {}, pausing for 30 seconds".format(http_resp.status_code))
+                # keep kafka producer connection alive
+                producer.poll(0)
                 time.sleep(30.0)
                 continue
             http_resp.raise_for_status()

--- a/python/fatcat_tools/harvest/doi_registrars.py
+++ b/python/fatcat_tools/harvest/doi_registrars.py
@@ -7,7 +7,7 @@ import time
 import itertools
 import datetime
 import requests
-from confluent_kafka import Producer
+from confluent_kafka import Producer, KafkaException
 
 from fatcat_tools.workers import most_recent_message
 from .harvest_common import HarvestState, requests_retry_session

--- a/python/fatcat_tools/harvest/harvest_common.py
+++ b/python/fatcat_tools/harvest/harvest_common.py
@@ -150,7 +150,7 @@ class HarvestState:
             'group.id': kafka_topic + "-init",
         })
         consumer = Consumer(conf)
-        consumer.assign([TopicPartition(kafka_topic, 0, OFFSET_BEGINNING)])
+        consumer.assign([TopicPartition(kafka_topic, 0, 0)])
         c = 0
         while True:
             msg = consumer.poll(timeout=1.0)
@@ -158,7 +158,7 @@ class HarvestState:
                 break
             if msg.error():
                 raise KafkaException(msg.error())
-            sys.stdout.write('.') # XXX:
+            #sys.stdout.write('.')
             self.update(msg.value().decode('utf-8'))
             c += 1
         consumer.close()

--- a/python/fatcat_tools/harvest/oaipmh.py
+++ b/python/fatcat_tools/harvest/oaipmh.py
@@ -8,7 +8,7 @@ import itertools
 import datetime
 import requests
 import sickle
-from confluent_kafka import Producer
+from confluent_kafka import Producer, KafkaException
 
 from fatcat_tools.workers import most_recent_message
 from .harvest_common import HarvestState

--- a/python/fatcat_tools/harvest/oaipmh.py
+++ b/python/fatcat_tools/harvest/oaipmh.py
@@ -52,14 +52,14 @@ class HarvestOaiPmhWorker:
         self.state = HarvestState(start_date, end_date)
         self.state.initialize_from_kafka(self.state_topic, self.kafka_config)
 
-    def kafka_produce_delivery_callback(err, msg):
-        if err is not None:
-            print("Kafka producer delivery error: {}".format(err))
-            print("Bailing out...")
-            # TODO: should it be sys.exit(-1)?
-            raise KafkaException(err)
-
     def fetch_date(self, date):
+
+        def fail_fast(err, msg):
+            if err is not None:
+                print("Kafka producer delivery error: {}".format(err))
+                print("Bailing out...")
+                # TODO: should it be sys.exit(-1)?
+                raise KafkaException(err)
 
         producer = Producer(self.kafka_config)
 
@@ -86,7 +86,7 @@ class HarvestOaiPmhWorker:
                 self.produce_topic,
                 item.raw.encode('utf-8'),
                 key=item.header.identifier.encode('utf-8'),
-                on_delivery=self.kafka_produce_delivery_callback)
+                on_delivery=fail_fast)
             producer.poll(0)
         producer.flush()
 

--- a/python/fatcat_tools/harvest/oaipmh.py
+++ b/python/fatcat_tools/harvest/oaipmh.py
@@ -40,6 +40,7 @@ class HarvestOaiPmhWorker:
         self.kafka_config = {
             'bootstrap.servers': kafka_hosts,
             'delivery.report.only.error': True,
+            'message.max.bytes': 20000000, # ~20 MBytes; broker is ~50 MBytes
             'default.topic.config':
                 {'request.required.acks': 'all'},
         }

--- a/python/fatcat_tools/importers/common.py
+++ b/python/fatcat_tools/importers/common.py
@@ -7,7 +7,7 @@ import ftfy
 import itertools
 import subprocess
 from collections import Counter
-import pykafka
+from confluent_kafka import Consumer, KafkaException
 
 import fatcat_client
 from fatcat_client.rest import ApiException
@@ -429,35 +429,88 @@ class KafkaJsonPusher(RecordPusher):
             topic_suffix,
             group,
         )
+        self.edit_batch_size = kwargs.get('edit_batch_size', 100)
 
     def run(self):
         count = 0
-        for msg in self.consumer:
-            if not msg:
+        while True:
+            batch = self.consumer.consume(
+                num_messages=self.edit_batch_size,
+                timeout=3.0)
+            print("... got {} kafka messages".format(len(batch)))
+            if not batch:
+                # TODO: could have some larger timeout here and
+                # self.importer.finish() if it's been more than, eg, a couple
+                # minutes
                 continue
-            record = json.loads(msg.value.decode('utf-8'))
-            self.importer.push_record(record)
-            count += 1
-            if count % 500 == 0:
-                print("Import counts: {}".format(self.importer.counts))
+            # first check errors on entire batch...
+            for msg in batch:
+                if msg.error():
+                    raise KafkaException(msg.error())
+            # ... then process
+            for msg in batch:
+                record = json.loads(msg.value().decode('utf-8'))
+                self.importer.push_record(record)
+                count += 1
+                if count % 500 == 0:
+                    print("Import counts: {}".format(self.importer.counts))
+            # locally store the last processed message; will be auto-commited
+            # from this "stored" value
+            assert msg
+            self.consumer.store_offsets(msg)
         # TODO: should catch UNIX signals (HUP?) to shutdown cleanly, and/or
         # commit the current batch if it has been lingering
         counts = self.importer.finish()
         print(counts)
+        self.consumer.close()
         return counts
 
 
 def make_kafka_consumer(hosts, env, topic_suffix, group):
-    topic_name = "fatcat-{}.{}".format(env, topic_suffix).encode('utf-8')
-    client = pykafka.KafkaClient(hosts=hosts, broker_version="1.0.0")
-    consume_topic = client.topics[topic_name]
-    print("Consuming from kafka topic {}, group {}".format(topic_name, group))
+    topic_name = "fatcat-{}.{}".format(env, topic_suffix)
 
-    consumer = consume_topic.get_balanced_consumer(
-        consumer_group=group.encode('utf-8'),
-        managed=True,
-        auto_commit_enable=True,
-        auto_commit_interval_ms=30000, # 30 seconds
-        compacted_topic=True,
+    def fail_fast(err, partitions):
+        if err is not None:
+            print("Kafka consumer commit error: {}".format(err))
+            print("Bailing out...")
+            # TODO: should it be sys.exit(-1)?
+            raise KafkaException(err)
+        for p in partitions:
+            # check for partition-specific commit errors
+            print(p)
+            if p.error:
+                print("Kafka consumer commit error: {}".format(p.error))
+                print("Bailing out...")
+                # TODO: should it be sys.exit(-1)?
+                raise KafkaException(err)
+        #print("Kafka consumer commit successful")
+        pass
+
+    # previously, using pykafka
+    #auto_commit_enable=True,
+    #auto_commit_interval_ms=30000, # 30 seconds
+    conf = {
+        'bootstrap.servers': hosts,
+        'group.id': group.encode('utf-8'),
+        'on_commit': fail_fast,
+        'delivery.report.only.error': True,
+        'enable.auto.offset.store': False,
+        'default.topic.config': {
+            'request.required.acks': -1,
+            'auto.offset.reset': 'latest',
+        },
+    }
+
+    def on_rebalance(consumer, partitions):
+        print("Kafka partitions rebalanced: {} / {}".format(
+            consumer, partitions))
+
+    consumer = Consumer(conf)
+    # NOTE: it's actually important that topic_name *not* be bytes (UTF-8
+    # encoded)
+    consumer.subscribe([topic_name],
+        on_assign=on_rebalance,
+        on_revoke=on_rebalance,
     )
+    print("Consuming from kafka topic {}, group {}".format(topic_name, group))
     return consumer

--- a/python/fatcat_tools/importers/common.py
+++ b/python/fatcat_tools/importers/common.py
@@ -502,6 +502,9 @@ def make_kafka_consumer(hosts, env, topic_suffix, group):
     }
 
     def on_rebalance(consumer, partitions):
+        for p in partitions:
+            if p.error:
+                raise KafkaException(p.error)
         print("Kafka partitions rebalanced: {} / {}".format(
             consumer, partitions))
 

--- a/python/fatcat_tools/workers/changelog.py
+++ b/python/fatcat_tools/workers/changelog.py
@@ -1,7 +1,7 @@
 
 import json
 import time
-from pykafka.common import OffsetType
+from confluent_kafka import Consumer, Producer, KafkaException
 
 from .worker_common import FatcatWorker, most_recent_message
 
@@ -12,7 +12,7 @@ class ChangelogWorker(FatcatWorker):
     found, fetch them and push (as JSON) into a Kafka topic.
     """
 
-    def __init__(self, api, kafka_hosts, produce_topic, poll_interval=10.0, offset=None):
+    def __init__(self, api, kafka_hosts, produce_topic, poll_interval=5.0, offset=None):
         # TODO: should be offset=0
         super().__init__(kafka_hosts=kafka_hosts,
                          produce_topic=produce_topic,
@@ -21,38 +21,47 @@ class ChangelogWorker(FatcatWorker):
         self.offset = offset    # the fatcat changelog offset, not the kafka offset
 
     def run(self):
-        topic = self.kafka.topics[self.produce_topic]
+
         # On start, try to consume the most recent from the topic, and using
         # that as the starting offset. Note that this is a single-partition
         # topic
         if self.offset is None:
             print("Checking for most recent changelog offset...")
-            msg = most_recent_message(topic)
+            msg = most_recent_message(self.produce_topic, self.kafka_config)
             if msg:
                 self.offset = json.loads(msg.decode('utf-8'))['index']
             else:
-                self.offset = 1
+                self.offset = 0
+            print("Most recent changelog index in Kafka seems to be {}".format(self.offset))
 
-        with topic.get_producer(
-                max_request_size=self.produce_max_request_size,
-                ) as producer:
-            while True:
-                latest = int(self.api.get_changelog(limit=1)[0].index)
-                if latest > self.offset:
-                    print("Fetching changelogs from {} through {}".format(
-                        self.offset+1, latest))
-                for i in range(self.offset+1, latest+1):
-                    cle = self.api.get_changelog_entry(i)
-                    obj = self.api.api_client.sanitize_for_serialization(cle)
-                    producer.produce(
-                        message=json.dumps(obj).encode('utf-8'),
-                        partition_key=None,
-                        timestamp=None,
-                        #NOTE could be (???): timestamp=cle.timestamp,
-                    )
-                    self.offset = i
-                print("Sleeping {} seconds...".format(self.poll_interval))
-                time.sleep(self.poll_interval)
+        def fail_fast(err, msg):
+            if err is not None:
+                print("Kafka producer delivery error: {}".format(err))
+                print("Bailing out...")
+                # TODO: should it be sys.exit(-1)?
+                raise KafkaException(err)
+
+        producer = Producer(self.kafka_config)
+
+        while True:
+            latest = int(self.api.get_changelog(limit=1)[0].index)
+            if latest > self.offset:
+                print("Fetching changelogs from {} through {}".format(
+                    self.offset+1, latest))
+            for i in range(self.offset+1, latest+1):
+                cle = self.api.get_changelog_entry(i)
+                obj = self.api.api_client.sanitize_for_serialization(cle)
+                producer.produce(
+                    self.produce_topic,
+                    json.dumps(obj).encode('utf-8'),
+                    key=str(i),
+                    on_delivery=fail_fast,
+                    #NOTE timestamp could be timestamp=cle.timestamp (?)
+                )
+                self.offset = i
+            producer.poll(0)
+            print("Sleeping {} seconds...".format(self.poll_interval))
+            time.sleep(self.poll_interval)
 
 
 class EntityUpdatesWorker(FatcatWorker):
@@ -63,45 +72,94 @@ class EntityUpdatesWorker(FatcatWorker):
     For now, only release updates are published.
     """
 
-    def __init__(self, api, kafka_hosts, consume_topic, release_topic):
+    def __init__(self, api, kafka_hosts, consume_topic, release_topic, poll_interval=5.0):
         super().__init__(kafka_hosts=kafka_hosts,
                          consume_topic=consume_topic,
                          api=api)
         self.release_topic = release_topic
+        self.poll_interval = poll_interval
         self.consumer_group = "entity-updates"
 
     def run(self):
-        changelog_topic = self.kafka.topics[self.consume_topic]
-        release_topic = self.kafka.topics[self.release_topic]
 
-        consumer = changelog_topic.get_balanced_consumer(
-            consumer_group=self.consumer_group,
-            managed=True,
-            auto_offset_reset=OffsetType.LATEST,
-            reset_offset_on_start=False,
-            fetch_message_max_bytes=4000000, # up to ~4MBytes
-            auto_commit_enable=True,
-            auto_commit_interval_ms=30000, # 30 seconds
-            compacted_topic=True,
+        def fail_fast(err, msg):
+            if err is not None:
+                print("Kafka producer delivery error: {}".format(err))
+                print("Bailing out...")
+                # TODO: should it be sys.exit(-1)?
+                raise KafkaException(err)
+
+        def on_commit(err, partitions):
+            if err is not None:
+                print("Kafka consumer commit error: {}".format(err))
+                print("Bailing out...")
+                # TODO: should it be sys.exit(-1)?
+                raise KafkaException(err)
+            for p in partitions:
+                # check for partition-specific commit errors
+                print(p)
+                if p.error:
+                    print("Kafka consumer commit error: {}".format(p.error))
+                    print("Bailing out...")
+                    # TODO: should it be sys.exit(-1)?
+                    raise KafkaException(err)
+            print("Kafka consumer commit successful")
+            pass
+
+        def on_rebalance(consumer, partitions):
+            for p in partitions:
+                if p.error:
+                    raise KafkaException(p.error)
+            print("Kafka partitions rebalanced: {} / {}".format(
+                consumer, partitions))
+
+        consumer_conf = self.kafka_config.copy()
+        consumer_conf.update({
+            'group.id': self.consumer_group,
+            'enable.auto.offset.store': False,
+            'default.topic.config': {
+                'auto.offset.reset': 'latest',
+            },
+        })
+        consumer = Consumer(consumer_conf)
+
+        producer_conf = self.kafka_config.copy()
+        producer_conf.update({
+            'default.topic.config': {
+                'request.required.acks': -1,
+            },
+        })
+        producer = Producer(producer_conf)
+
+        consumer.subscribe([self.consume_topic],
+            on_assign=on_rebalance,
+            on_revoke=on_rebalance,
         )
+        print("Kafka consuming {}".format(self.consume_topic))
 
-        # using a sync producer to try and avoid racey loss of delivery (aka,
-        # if consumer group updated but produce didn't stick)
-        with release_topic.get_sync_producer(
-                max_request_size=self.produce_max_request_size,
-                ) as producer:
-            for msg in consumer:
-                cle = json.loads(msg.value.decode('utf-8'))
-                #print(cle)
-                print("processing changelog index {}".format(cle['index']))
-                release_edits = cle['editgroup']['edits']['releases']
-                for re in release_edits:
-                    ident = re['ident']
-                    release = self.api.get_release(ident, expand="files,filesets,webcaptures,container")
-                    release_dict = self.api.api_client.sanitize_for_serialization(release)
-                    producer.produce(
-                        message=json.dumps(release_dict).encode('utf-8'),
-                        partition_key=ident.encode('utf-8'),
-                        timestamp=None,
-                    )
-                #consumer.commit_offsets()
+        while True:
+            msg = consumer.poll(self.poll_interval)
+            if not msg:
+                print("nothing new from kafka (interval:{})".format(self.poll_interval))
+                consumer.commit()
+                continue
+            if msg.error():
+                raise KafkaException(msg.error())
+
+            cle = json.loads(msg.value().decode('utf-8'))
+            #print(cle)
+            print("processing changelog index {}".format(cle['index']))
+            release_edits = cle['editgroup']['edits']['releases']
+            for re in release_edits:
+                ident = re['ident']
+                release = self.api.get_release(ident, expand="files,filesets,webcaptures,container")
+                # TODO: use .to_json() helper
+                release_dict = self.api.api_client.sanitize_for_serialization(release)
+                producer.produce(
+                    self.release_topic,
+                    json.dumps(release_dict).encode('utf-8'),
+                    key=ident.encode('utf-8'),
+                    on_delivery=fail_fast,
+                )
+            consumer.store_offsets(msg)
+

--- a/python/fatcat_worker.py
+++ b/python/fatcat_worker.py
@@ -44,8 +44,8 @@ def main():
         default="localhost:9092",
         help="list of Kafka brokers (host/port) to use")
     parser.add_argument('--env',
-        default="qa",
-        help="Kafka topic namespace to use (eg, prod, qa)")
+        default="dev",
+        help="Kafka topic namespace to use (eg, prod, qa, dev)")
     subparsers = parser.add_subparsers()
 
     sub_changelog = subparsers.add_parser('changelog')

--- a/python/fatcat_worker.py
+++ b/python/fatcat_worker.py
@@ -52,7 +52,7 @@ def main():
     sub_changelog.set_defaults(func=run_changelog)
     sub_changelog.add_argument('--poll-interval',
         help="how long to wait between polling (seconds)",
-        default=10.0, type=float)
+        default=5.0, type=float)
 
     sub_entity_updates = subparsers.add_parser('entity-updates')
     sub_entity_updates.set_defaults(func=run_entity_updates)


### PR DESCRIPTION
Not sure i'll even keep this branch, but this was helpful for me to work out what the issues are.

One "ah hah" is that in consumers you can leave auto "commit" enabled, but disable `enable.auto.offset.store`. I think this lets the Kafka brokers know that the consumer is still alive (because the no-op commits are still happening in a background thread) when application processing takes a long time.

The "fetch most recent message" function needs review. Does it work when: topic is new/blank/empty, when messages are partially replicated, etc. 

Some refactors to do:
- definitely pull all the kafka handlers (`on_delivery` et al) into a single place (DRY)
- make the harvesters more generic (producing code is duplicated)
- refactor harvesters to have iterators over sources, and simple wrapper to push results to kafka and maintain state (for easier testing)
- consider more wrappers/helpers
- should probably start using an elasticsearch client library instead of hand-rolling things like the batch indexing
- add any testing of all: mock harvesters, end-to-end pipeline tests that check for local kafka/elasticsearch and skips if not running, etc