### PR TITLE
Travis CI: Lint Python code for syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-os: linux
-dist: focal
-language: python
-python: 3.8
-install: pip install flake8
-script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+os: linux
 dist: focal
 language: python
+python: 3.8
 install: pip install flake8
 script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+dist: focal
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,15 +5,15 @@ The schema files are:
 
     Copyright, 2018 Bryan Newbold <bnewbold@robocracy.org)
 
-The python 'fatcat_openapi_client' API client library (under the
+The Python 'fatcat_openapi_client' API client library (under the
 ./python/fatcat_openapi_client/ directory), which is auto-generated from a
 swagger/openapi schema specification, is released to the public domain.
 
-The rust 'fatcat-openapi' API library (under the ./rust/fatcat-openapi/
+The Rust 'fatcat-openapi' API library (under the ./rust/fatcat-openapi/
 directory), which is auto-generated from the swagger/openapi schema
 specification, is released to the public domain.
 
-The python 'fatcat' web interface, tests, scripts, and bots (under the
+The Python 'fatcat' web interface, tests, scripts, and bots (under the
 ./python/ directory, not including fatcat_openapi_client), unless otherwise specified
 are released under the GNU Affero General Public License, version 3. A copy of
 this license should be included in this repository. Unless otherwise indicated
@@ -21,7 +21,7 @@ this code is:
 
     Copyright, 2018 Bryan Newbold <bnewbold@robocracy.org)
 
-The rust 'fatcat' API server, tests, scripts, and associated programs (under
+The Rust 'fatcat' API server, tests, scripts, and associated programs (under
 the ./rust/fatcat/ directory), unless otherwise specified are released under
 the GNU Affero General Public License, version 3. A copy of this license should
 be included in this repository. Unless otherwise indicated this code is:

--- a/python/fatcat_tools/importers/jalc.py
+++ b/python/fatcat_tools/importers/jalc.py
@@ -201,11 +201,11 @@ class JalcImporter(EntityImporter):
         date = record.date or None
         if date:
             date = date.string
-            if len(date) is 10:
+            if len(date) == 10:
                 release_date = datetime.datetime.strptime(date['completed-date'], DATE_FMT).date()
                 release_year = release_date.year
                 release_date = release_date.isoformat()
-            elif len(date) is 4 and date.isdigit():
+            elif len(date) == 4 and date.isdigit():
                 release_year = int(date)
 
         pages = None

--- a/python/tests/harvest_state.py
+++ b/python/tests/harvest_state.py
@@ -11,7 +11,7 @@ def test_harvest_state():
 
     hs = HarvestState(catchup_days=5)
     assert max(hs.to_process) < today
-    assert len(hs.to_process) is 5
+    assert len(hs.to_process) == 5
 
     for d in list(hs.to_process):
         hs.complete(d)
@@ -22,12 +22,12 @@ def test_harvest_state():
         start_date=datetime.date(2000,1,1),
         end_date=datetime.date(2000,1,3),
     )
-    assert len(hs.to_process) is 3
+    assert len(hs.to_process) == 3
     hs = HarvestState(
         start_date=datetime.date(2000,1,29),
         end_date=datetime.date(2000,2,2),
     )
-    assert len(hs.to_process) is 5
+    assert len(hs.to_process) == 5
 
     hs = HarvestState(catchup_days=0)
     assert hs.next() is None
@@ -35,6 +35,6 @@ def test_harvest_state():
         start_date=datetime.date(2000,1,1),
         end_date=datetime.date(2000,1,3),
     )
-    assert len(hs.to_process) is 3
+    assert len(hs.to_process) == 3
     hs.update('{"completed-date": "2000-01-02"}')
-    assert len(hs.to_process) is 2
+    assert len(hs.to_process) == 2


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.