### PR TITLE
GitLab CI: Allow flake8 to lint ALL Python files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,3 @@
-
 # Rust caching causing bloat and using too much disk space in public gitlab.com
 # CI process
 #cache:
@@ -53,7 +52,7 @@ unified_test:
     - pipenv run ./tests/cli.sh
     # Just errors
     - pipenv run pylint -E fatcat*.py fatcat_tools fatcat_web tests/*.py
-    - pipenv run flake8 tests/ fatcat_web/ fatcat_tools/ *.py --count --select=E9,F63,F7,F82 --show-source --statistics
+    - pipenv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 rust_build_release:
   stage: build


### PR DESCRIPTION
Why lint only a subset of the [Python files in this repo](https://github.com/internetarchive/fatcat/search?l=python)?

Given how excruciatingly slow the rust tests run, perhaps it would be better to fast fail by running the Python tests first and the rust tests last.  Or better yet to run the tests in parallel jobs.