### PR TITLE
hide abstract format if None

### DIFF
--- a/python/fatcat_web/templates/release_view.html
+++ b/python/fatcat_web/templates/release_view.html
@@ -121,9 +121,13 @@
 {% if release.abstracts != [] %}
   <h3>Abstract</h3>
   <p><span itemprop="description">{{ release.abstracts[0].content }}</span>
-  {%- if release.abstracts[0].mimetype != None %}
-    <br><small><i>In <code>{{ release.abstracts[0].mimetype }}</code> format</i></small>
-  {% endif %}
+  <br><small><i>
+    {%- if release.abstracts[0].mimetype != None %}
+      In <code>{{ release.abstracts[0].mimetype }}</code> format
+    {% else %}
+      Unknown format
+    {% endif %}
+  </i></small>
 {% endif %}
 
 {% if entity.state == 'active' %}

--- a/python/fatcat_web/templates/release_view.html
+++ b/python/fatcat_web/templates/release_view.html
@@ -121,7 +121,9 @@
 {% if release.abstracts != [] %}
   <h3>Abstract</h3>
   <p><span itemprop="description">{{ release.abstracts[0].content }}</span>
-  <br><small><i>In <code>{{ release.abstracts[0].mimetype }}</code> format</i></small>
+  {%- if release.abstracts[0].mimetype != None %}
+    <br><small><i>In <code>{{ release.abstracts[0].mimetype }}</code> format</i></small>
+  {% endif %}
 {% endif %}
 
 {% if entity.state == 'active' %}


### PR DESCRIPTION
Since a type is "[not formally required](https://guide.fatcat.wiki/entity_release.html)", it might be good to hide it if `None` is specified. Example:

[![image](https://user-images.githubusercontent.com/12068939/153024376-0563ee0c-6ce9-4a75-a2f9-41cff3c51f42.png)](https://fatcat.wiki/release/t5pskdrbh5cd5p56ecqta3sbsq)
